### PR TITLE
Add .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+# JetBrains IDEs
+.idea/
+
+# macOS
+.DS_Store
+
+# Node / general logs (just in case)
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Archives
+*.zip
+*.tar
+*.tar.gz
+*.rar
+
+# Thumbnails
+._*


### PR DESCRIPTION
Introduced a .gitignore file to exclude IDE settings, OS-specific files, log files, archives, and thumbnails from version control.

